### PR TITLE
add closeConnection

### DIFF
--- a/include/AndorCamera.h
+++ b/include/AndorCamera.h
@@ -253,6 +253,7 @@ namespace lima
 	    //void setReadMode(ReadMode mode);
 	    void setBaselineClamp(BaselineClamp mode);
 	    void getBaselineClamp(BaselineClamp& mode);
+	    void closeConnection();
 
 	private:
 	    class _AcqThread;

--- a/sip/AndorCamera.sip
+++ b/sip/AndorCamera.sip
@@ -164,6 +164,7 @@ namespace Andor
     //void setReadMode(Andor::ReadMode mode);
     void setBaselineClamp(Andor::BaselineClamp mode);
     void getBaselineClamp(Andor::BaselineClamp& mode /Out/);
+    void closeConnection();
     
   private:
     Camera(const Andor::Camera&);

--- a/src/AndorCamera.cpp
+++ b/src/AndorCamera.cpp
@@ -232,6 +232,14 @@ Camera::Camera(const std::string& config_path,int camera_number)
 Camera::~Camera()
 {
     DEB_DESTRUCTOR();
+    closeConnection();
+}
+
+//---------------------------
+// @brief  Dtor
+//---------------------------
+void Camera::closeConnection()
+{
     // Stop Acq thread
     delete m_acq_thread;
     m_acq_thread = NULL;

--- a/tango/Andor.py
+++ b/tango/Andor.py
@@ -433,3 +433,13 @@ def get_control(config_path='/usr/local/etc/andor', camera_number = '0',**keys) 
 def get_tango_specific_class_n_device():
     return AndorClass,Andor
 
+
+# =============================================================================
+# =============================================================================
+# called by ->  delete_device (LimaCCDs.py:352)
+# requiered to close properly the camera / sdk
+#   because the cam, interface destructors are called in wrong order
+# =============================================================================
+def close_interface():
+    print("... close_interface()")
+    _AndorCamera.closeConnection()


### PR DESCRIPTION
It looks like destructor of global variable `_AndorCamera` is called by garbage collector too late (i.e. in wrong order) so it is good to call its content from `delete_device` of `LimaCCDs` via `close_interface()` method. It is simmilar case to PCO.